### PR TITLE
Allow models to be passed as a string rather than as files

### DIFF
--- a/lib/scoruby.rb
+++ b/lib/scoruby.rb
@@ -21,6 +21,11 @@ module Scoruby
     ModelFactory.factory_for(xml)
   end
 
+  def self.load_model_from_string(pmml_string)
+    xml = xml_from_string(pmml_string)
+    ModelFactory.factory_for(xml)
+  end
+
   def self.xml_from_file_path(pmml_file_name)
     pmml_string = File.open(pmml_file_name, 'rb').read
     xml_from_string(pmml_string)


### PR DESCRIPTION
We are storing the model in a persisted cache as a string, and so require scoruby to load the model from a string.

We didn't feel that any tests were necessary as we're not really changing the logic here, but if you've got any suggestions, we'd be happy to implement them.