### PR TITLE
Regression support for random forest

### DIFF
--- a/lib/scoruby/models/random_forest/data.rb
+++ b/lib/scoruby/models/random_forest/data.rb
@@ -25,6 +25,10 @@ module Scoruby
           @continuous_features ||= fetch_continuous_features
         end
 
+        def regression?
+          @xml.xpath("//MiningModel[@functionName='regression']").any?
+        end
+
         private
 
         def fetch_continuous_features


### PR DESCRIPTION
Hey @asafschers, thanks for this awesome gem 👍 

This PR adds support for regression to random forest. Regression does a weighted average of the decision counts. I wasn't sure what to call the key in the return value, so went with `response`.